### PR TITLE
Removed a print statement

### DIFF
--- a/lib/widgets/Window.lua
+++ b/lib/widgets/Window.lua
@@ -224,7 +224,6 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             end
 
             if not inWindow then
-                print("Outside")
                 Iris.SetFocusedWindow(nil)
             end
         end


### PR DESCRIPTION
When using Iris I noticed a "Outside" message in console whenever I mouse clicked. This lead me to figuring out what is going on and if it needed. I assume its not since it is the only print in the whole of Iris so I assume it was left in by mistake.