### PR TITLE
Added changed Event and Fixed click Events for Combo

### DIFF
--- a/docs/about/states.md
+++ b/docs/about/states.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 3	
+sidebar_position: 3
 ---
 
-# Understanding State	
+# Understanding State
 
 An Iris State object is simply a table containg a value, and an array of connected widgets. It provides functions to
 get or set the value, the latter of which will update any widgets UI that are dependent on that state. Functions can

--- a/docs/common_issues.md
+++ b/docs/common_issues.md
@@ -70,9 +70,9 @@ outside of an Iris widget, or spawn a new thread. The example below demonstrates
 --- bad_example.lua
 -----------------------
  4| Iris.Window({"Async Window"})
- 5| 	-- this code yeilds which will prevent Iris from finishing before the next frame
- 6| 	local response = httpService:GetAsync(...)
- 7| 	Iris.Text(response)
+ 5|     -- this code yeilds which will prevent Iris from finishing before the next frame
+ 6|     local response = httpService:GetAsync(...)
+ 7|     Iris.Text(response)
  8| Iris.End()
 
 ------------------------
@@ -81,11 +81,11 @@ outside of an Iris widget, or spawn a new thread. The example below demonstrates
  4| local response = "NONE"
  5| 
  6| Iris.Window({"Async Window"})
- 7| 	-- we use another thread to ensure the thread Iris is in will finish before the next frame
- 8| 	task.spawn(function()
- 9| 		response = httpService:GetAsync(...)
-10| 	end)
-11| 	Iris.Text(response)
+ 7|     -- we use another thread to ensure the thread Iris is in will finish before the next frame
+ 8|     task.spawn(function()
+ 9|         response = httpService:GetAsync(...)
+10|     end)
+11|     Iris.Text(response)
 12| Iris.End()
 ```
 
@@ -106,7 +106,7 @@ children and make it clearer to see where an `Iris.End()` statement must go. For
 ```lua
  4| Iris.Window({ "Do-End Block" })
  5| do
- 6| 	Iris.Text({ "Text goes here." })
+ 6|     Iris.Text({ "Text goes here." })
  7| end
  8| Iris.End()
 ```
@@ -117,7 +117,7 @@ This issue may also arise if some of your code either yields or errors and there
 
 ```lua
  4| Iris.Window({ "Valid Code with Error" })
- 5| 	error("Something has gone wrong. :(") -- errors within Iris
+ 5|     error("Something has gone wrong. :(") -- errors within Iris
  6| Iris.End()
 
  7| Iris.Window({ "Asynchronous Code" })

--- a/lib/API.lua
+++ b/lib/API.lua
@@ -1523,7 +1523,7 @@ return function(Iris: Types.Iris)
         Events = {
             opened: () -> boolean,
             closed: () -> boolean,
-			changed: () -> boolean,
+            changed: () -> boolean,
             clicked: () -> boolean,
             hovered: () -> boolean
         }

--- a/lib/API.lua
+++ b/lib/API.lua
@@ -1510,7 +1510,7 @@ return function(Iris: Types.Iris)
         @tag HasChildren
         @tag HasState
         
-        A selection box to choose a value from a range of values.
+        A dropdown menu box to make a selection from a list of values.
         
         ```lua
         hasChildren = true
@@ -1523,6 +1523,7 @@ return function(Iris: Types.Iris)
         Events = {
             opened: () -> boolean,
             closed: () -> boolean,
+			changed: () -> boolean,
             clicked: () -> boolean,
             hovered: () -> boolean
         }

--- a/lib/WidgetTypes.lua
+++ b/lib/WidgetTypes.lua
@@ -430,7 +430,7 @@ export type Combo = ParentWidget & {
     },
 
     UIListLayout: UIListLayout,
-} & Opened & Closed & Clicked & Hovered
+} & Opened & Closed & Changed & Clicked & Hovered
 
 -- Plot
 

--- a/lib/widgets/Combo.lua
+++ b/lib/widgets/Combo.lua
@@ -235,14 +235,14 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     return thisWidget.lastClosedTick == Iris._cycleTick
                 end,
             },
-			["changed"] = {
-				["Init"] = function(_thisWidget: Types.Combo) end,
-				["Get"] = function(thisWidget: Types.Combo)
-					return thisWidget.lastChangedTick == Iris._cycleTick
-				end,
-			},
+            ["changed"] = {
+                ["Init"] = function(_thisWidget: Types.Combo) end,
+                ["Get"] = function(thisWidget: Types.Combo)
+                    return thisWidget.lastChangedTick == Iris._cycleTick
+                end,
+            },
             ["clicked"] = widgets.EVENTS.click(function(thisWidget: Types.Widget)
-				local Combo = thisWidget.Instance :: Frame
+                local Combo = thisWidget.Instance :: Frame
                 return Combo.PreviewContainer
             end),
             ["hovered"] = widgets.EVENTS.hover(function(thisWidget: Types.Widget)
@@ -439,7 +439,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             end
             thisWidget.state.index:onChange(function()
                 if thisWidget.state.isOpened.value then
-					thisWidget.lastChangedTick = Iris._cycleTick + 1
+                    thisWidget.lastChangedTick = Iris._cycleTick + 1
                     thisWidget.state.isOpened:set(false)
                 end
             end)
@@ -480,11 +480,11 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             PreviewLabel.Text = if typeof(stateIndex) == "EnumItem" then stateIndex.Name else tostring(stateIndex)
         end,
         Discard = function(thisWidget: Types.Combo)
-			-- If we are discarding the current combo active, we need to hide it
-			if OpenedCombo and OpenedCombo == thisWidget then
-				OpenedCombo = nil
-				AnyOpenedCombo = false
-			end
+            -- If we are discarding the current combo active, we need to hide it
+            if OpenedCombo and OpenedCombo == thisWidget then
+                OpenedCombo = nil
+                AnyOpenedCombo = false
+            end
 
             thisWidget.Instance:Destroy()
             thisWidget.ChildContainer:Destroy()

--- a/lib/widgets/Combo.lua
+++ b/lib/widgets/Combo.lua
@@ -235,11 +235,19 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     return thisWidget.lastClosedTick == Iris._cycleTick
                 end,
             },
+			["changed"] = {
+				["Init"] = function(_thisWidget: Types.Combo) end,
+				["Get"] = function(thisWidget: Types.Combo)
+					return thisWidget.lastChangedTick == Iris._cycleTick
+				end,
+			},
             ["clicked"] = widgets.EVENTS.click(function(thisWidget: Types.Widget)
-                return thisWidget.Instance
+				local Combo = thisWidget.Instance :: Frame
+                return Combo.PreviewContainer
             end),
             ["hovered"] = widgets.EVENTS.hover(function(thisWidget: Types.Widget)
-                return thisWidget.Instance
+				local Combo = thisWidget.Instance :: Frame
+                return Combo.PreviewContainer
             end),
         },
         Generate = function(thisWidget: Types.Combo)
@@ -432,6 +440,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             end
             thisWidget.state.index:onChange(function()
                 if thisWidget.state.isOpened.value then
+					thisWidget.lastChangedTick = Iris._cycleTick + 1
                     thisWidget.state.isOpened:set(false)
                 end
             end)

--- a/lib/widgets/Combo.lua
+++ b/lib/widgets/Combo.lua
@@ -246,8 +246,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 return Combo.PreviewContainer
             end),
             ["hovered"] = widgets.EVENTS.hover(function(thisWidget: Types.Widget)
-				local Combo = thisWidget.Instance :: Frame
-                return Combo.PreviewContainer
+                return thisWidget.Instance
             end),
         },
         Generate = function(thisWidget: Types.Combo)

--- a/lib/widgets/Combo.lua
+++ b/lib/widgets/Combo.lua
@@ -438,8 +438,8 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 thisWidget.state.index = Iris._widgetState(thisWidget, "index", "No Selection")
             end
             thisWidget.state.index:onChange(function()
+                thisWidget.lastChangedTick = Iris._cycleTick + 1
                 if thisWidget.state.isOpened.value then
-                    thisWidget.lastChangedTick = Iris._cycleTick + 1
                     thisWidget.state.isOpened:set(false)
                 end
             end)

--- a/lib/widgets/Combo.lua
+++ b/lib/widgets/Combo.lua
@@ -437,15 +437,16 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             if thisWidget.state.index == nil then
                 thisWidget.state.index = Iris._widgetState(thisWidget, "index", "No Selection")
             end
+            if thisWidget.state.isOpened == nil then
+                thisWidget.state.isOpened = Iris._widgetState(thisWidget, "isOpened", false)
+            end
+            
             thisWidget.state.index:onChange(function()
                 thisWidget.lastChangedTick = Iris._cycleTick + 1
                 if thisWidget.state.isOpened.value then
                     thisWidget.state.isOpened:set(false)
                 end
             end)
-            if thisWidget.state.isOpened == nil then
-                thisWidget.state.isOpened = Iris._widgetState(thisWidget, "isOpened", false)
-            end
         end,
         UpdateState = function(thisWidget: Types.Combo)
             local Combo = thisWidget.Instance :: Frame

--- a/lib/widgets/Image.lua
+++ b/lib/widgets/Image.lua
@@ -19,8 +19,8 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
         end,
     } :: Types.WidgetClass
 
-	--stylua: ignore
-	Iris.WidgetConstructor("Image", widgets.extend(abstractImage, {
+    --stylua: ignore
+    Iris.WidgetConstructor("Image", widgets.extend(abstractImage, {
             Events = {
                 ["hovered"] = widgets.EVENTS.hover(function(thisWidget: Types.Widget)
                     return thisWidget.Instance
@@ -67,8 +67,8 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                     Image.ResampleMode = thisWidget.arguments.ResampleMode
                 end
             end,
-		} :: Types.WidgetClass)
-	)
+        } :: Types.WidgetClass)
+    )
 
     --stylua: ignore
     Iris.WidgetConstructor("ImageButton", widgets.extend(abstractImage, {

--- a/lib/widgets/Menu.lua
+++ b/lib/widgets/Menu.lua
@@ -445,11 +445,11 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
             TextLabel.Text = thisWidget.arguments.Text
             if thisWidget.arguments.KeyCode then
-				if thisWidget.arguments.ModifierKey then
-					Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
-				else
-					Shortcut.Text = thisWidget.arguments.KeyCode.Name
-				end
+                if thisWidget.arguments.ModifierKey then
+                    Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
+                else
+                    Shortcut.Text = thisWidget.arguments.KeyCode.Name
+                end
             end
         end,
         Discard = function(thisWidget: Types.MenuItem)
@@ -579,11 +579,11 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
 
             TextLabel.Text = thisWidget.arguments.Text
             if thisWidget.arguments.KeyCode then
-				if thisWidget.arguments.ModifierKey then
-					Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
-				else
-					Shortcut.Text = thisWidget.arguments.KeyCode.Name
-				end
+                if thisWidget.arguments.ModifierKey then
+                    Shortcut.Text = thisWidget.arguments.ModifierKey.Name .. " + " .. thisWidget.arguments.KeyCode.Name
+                else
+                    Shortcut.Text = thisWidget.arguments.KeyCode.Name
+                end
             end
         end,
         UpdateState = function(thisWidget: Types.MenuToggle)

--- a/lib/widgets/Window.lua
+++ b/lib/widgets/Window.lua
@@ -1045,9 +1045,9 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 local desiredCycleTick: number = Iris._cycleTick + 1
                 Iris._postCycleCallbacks[callbackIndex] = function()
                     if Iris._cycleTick >= desiredCycleTick then
-						if thisWidget.lastCycleTick ~= -1 then
-                        	ChildContainer.CanvasPosition = Vector2.new(0, stateScrollDistance)
-						end
+                        if thisWidget.lastCycleTick ~= -1 then
+                            ChildContainer.CanvasPosition = Vector2.new(0, stateScrollDistance)
+                        end
                         Iris._postCycleCallbacks[callbackIndex] = nil
                     end
                 end

--- a/moonwave.toml
+++ b/moonwave.toml
@@ -14,20 +14,20 @@ classes = ["Iris", "State"]
 [[classOrder]]
 section = "Widgets"
 classes = [
-	"Window",
-	"Menu",
-	"Format",
-	"Text",
-	"Basic",
-	"Tree",
+    "Window",
+    "Menu",
+    "Format",
+    "Text",
+    "Basic",
+    "Tree",
     "Tab",
     "Image",
-	"Input",
-	"Drag",
-	"Slider",
-	"Combo",
-	"Plot",
-	"Table",
+    "Input",
+    "Drag",
+    "Slider",
+    "Combo",
+    "Plot",
+    "Table",
 ]
 
 [[classOrder]]


### PR DESCRIPTION
Added a new 'changed' event which fires when the combo box selection changes, which is better than using `closed` or caching the value.

Fixed the `clicked` event to only update when clicking the combo selection box and prevented from erroring.