### PR TITLE
Fix mobile interaction

### DIFF
--- a/lib/widgets/Window.lua
+++ b/lib/widgets/Window.lua
@@ -818,7 +818,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
             ResizeBorder.Position = UDim2.fromOffset(-Iris._config.WindowResizePadding.X, -Iris._config.WindowResizePadding.Y)
             ResizeBorder.BackgroundTransparency = 1
             ResizeBorder.BorderSizePixel = 0
-            ResizeBorder.Active = true
+            ResizeBorder.Active = false
             ResizeBorder.Selectable = false
             ResizeBorder.ClipsDescendants = false
             ResizeBorder.Parent = WindowButton


### PR DESCRIPTION
Doesn't appear to effect functionality on mobile or PC, beyond fixing the issue. For some reason, this frame sinks all input on mobile and doesn't pass through, which doesn't happen on desktop. I haven't added a check for whether the device is mobile, considering functionality remains unaffected on desktop by this patch from what it appears.

Tested in the Studio mobile device emulator.

All of the credit goes to https://devforum.roblox.com/t/iris-immediate-mode-ui-library-based-on-dear-imgui/2302802/238 for the fix - I just found it and applied it.

Closes #83 