### PR TITLE
Init now returns on multiple calls.

### DIFF
--- a/lib/Types.lua
+++ b/lib/Types.lua
@@ -612,7 +612,7 @@ export type Iris = {
         -------------
     ]]
 
-    Init: (playerInstance: BasePlayerGui?, eventConnection: (RBXScriptConnection | () -> () | false)?) -> Iris,
+    Init: (playerInstance: BasePlayerGui?, eventConnection: (RBXScriptConnection | () -> () | false)?, allowMultipleInits: boolean?) -> Iris,
     Shutdown: () -> (),
     Connect: (self: Iris, callback: () -> ()) -> () -> (),
     Append: (userInstance: GuiObject) -> (),

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -69,8 +69,9 @@ Iris.Events = {}
 
     If the `eventConnection` is `false` then Iris will not create a cycle loop and the user will need to call [Internal._cycle] every frame.
 ]=]
-function Iris.Init(parentInstance: Instance?, eventConnection: (RBXScriptSignal | (() -> number) | false)?): Types.Iris
+function Iris.Init(parentInstance: Instance?, eventConnection: (RBXScriptSignal | (() -> number) | false)?, allowMultipleInits: boolean): Types.Iris
     assert(Internal._shutdown == false, "Iris.Init() cannot be called once shutdown.")
+    assert(Internal._started == false or allowMultipleInits == true, "Iris.Init() can only be called once.")
 
     if Internal._started then
         return Iris

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -70,8 +70,11 @@ Iris.Events = {}
     If the `eventConnection` is `false` then Iris will not create a cycle loop and the user will need to call [Internal._cycle] every frame.
 ]=]
 function Iris.Init(parentInstance: Instance?, eventConnection: (RBXScriptSignal | (() -> number) | false)?): Types.Iris
-    assert(Internal._started == false, "Iris.Init() can only be called once.")
     assert(Internal._shutdown == false, "Iris.Init() cannot be called once shutdown.")
+
+    if Internal._started then
+        return Iris
+    end
 
     if parentInstance == nil then
         -- coalesce to playerGui


### PR DESCRIPTION
Can call `Iris.Init()` multiple times without getting errors. Although intialisation should only be done once, and I don't particularly like the idea, I think it should be fine.