### PR TITLE
Add ScreenInsets option for ScreenGuis

### DIFF
--- a/docs/about/config.md
+++ b/docs/about/config.md
@@ -30,6 +30,7 @@ Iris.UpdateGlobalConfig(Iris.TemplateConfig.colorLight) -- change to the templat
 Iris.UpdateGlobalConfig({
     RichText = true,
     IgnoreGuiInset = true,
+    ScreenInsets = Enum.ScreenInsets.None,
     TextColor = Color3.fromRGB(85, 49, 218),
     TextSize = 16,
     FramePadding = Vector2.new(2, 1),
@@ -181,16 +182,18 @@ The RichText option will allow any text instance to support rich text. Equivalen
 TextWrapped and these both rely on Roblox to handle support for this.
 
 UseScreenGUIs will determine whether the root UI instances are ScreenGUIs or Frames. This is useful
-for when Iris is put inside existing UI, such as plugins or stories.
+for when Iris is put inside existing UI, such as plugins or stories. ScreenInsets is applied first,
+so make sure that IgnoreGuiInset agrees with the value (false when CoreUISafeInsets, true otherwise).
 
-| Key                     | Value   | Notes                                                                 |
-| ----------------------- | ------- | --------------------------------------------------------------------- |
-| UseScreenGUIs           | `true`  | Whether to use ScreenGUIs as the top level widget, or Frames instead. |
-| IgnoreGuiInset          | `false` | If using ScreenGUIs                                                   |
-| Parent                  | `nil`   | Overrides the parent of the next widget, when creating                |
-| RichText                | `false` | Text instances support RichText                                       |
-| TextWrapped             | `false` | Text instances will wrap text                                         |
-| DisplayOrderOffset      | `127`   | Root widget offset, to draw over other UI                             |
-| ZIndexOffset            | `0`     | Unused                                                                |
-| MouseDoubleClickTime    | `0.30`  | Time for a double-click, in seconds                                   |
-| MouseDoubleClickMaxDist | `6.0`   | Distance threshold to stay in to validate a double-click, in pixels   |
+| Key                     | Value                                | Notes                                                                 |
+| ----------------------- | ------------------------------------ | --------------------------------------------------------------------- |
+| UseScreenGUIs           | `true`                               | Whether to use ScreenGUIs as the top level widget, or Frames instead. |
+| ScreenInsets            | `Enum.ScreenInsets.CoreUISafeInsets` | Type of screenInset for ScreenGUIs, useful for mobile.                |
+| IgnoreGuiInset          | `false`                              | If using ScreenGUIs                                                   |
+| Parent                  | `nil`                                | Overrides the parent of the next widget, when creating                |
+| RichText                | `false`                              | Text instances support RichText                                       |
+| TextWrapped             | `false`                              | Text instances will wrap text                                         |
+| DisplayOrderOffset      | `127`                                | Root widget offset, to draw over other UI                             |
+| ZIndexOffset            | `0`                                  | Unused                                                                |
+| MouseDoubleClickTime    | `0.30`                               | Time for a double-click, in seconds                                   |
+| MouseDoubleClickMaxDist | `6.0`                                | Distance threshold to stay in to validate a double-click, in pixels   |

--- a/lib/Types.lua
+++ b/lib/Types.lua
@@ -494,6 +494,7 @@ export type Config = {
 
     UseScreenGUIs: boolean,
     IgnoreGuiInset: boolean,
+    ScreenInsets: Enum.ScreenInsets,
     Parent: BasePlayerGui,
     RichText: boolean,
     TextWrapped: boolean,

--- a/lib/config.lua
+++ b/lib/config.lua
@@ -287,6 +287,7 @@ local TemplateConfig = {
     utilityDefault = {
         UseScreenGUIs = true,
         IgnoreGuiInset = false,
+        ScreenInsets = Enum.ScreenInsets.CoreUISafeInsets,
         Parent = nil,
         RichText = false,
         TextWrapped = false,

--- a/lib/widgets/Root.lua
+++ b/lib/widgets/Root.lua
@@ -18,6 +18,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 PseudoWindowScreenGui = Instance.new("ScreenGui")
                 PseudoWindowScreenGui.ResetOnSpawn = false
                 PseudoWindowScreenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+                PseudoWindowScreenGui.ScreenInsets = Iris._config.ScreenInsets
                 PseudoWindowScreenGui.IgnoreGuiInset = Iris._config.IgnoreGuiInset
                 PseudoWindowScreenGui.DisplayOrder = Iris._config.DisplayOrderOffset
             else
@@ -37,6 +38,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 PopupScreenGui.ResetOnSpawn = false
                 PopupScreenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
                 PopupScreenGui.DisplayOrder = Iris._config.DisplayOrderOffset + 1024 -- room for 1024 regular windows before overlap
+                PopupScreenGui.ScreenInsets = Iris._config.ScreenInsets
                 PopupScreenGui.IgnoreGuiInset = Iris._config.IgnoreGuiInset
             else
                 PopupScreenGui = Instance.new("Frame")

--- a/lib/widgets/Window.lua
+++ b/lib/widgets/Window.lua
@@ -389,6 +389,7 @@ return function(Iris: Types.Internal, widgets: Types.WidgetUtility)
                 Window.ResetOnSpawn = false
                 Window.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
                 Window.DisplayOrder = Iris._config.DisplayOrderOffset
+                Window.ScreenInsets = Iris._config.ScreenInsets
                 Window.IgnoreGuiInset = Iris._config.IgnoreGuiInset
             else
                 Window = Instance.new("Frame")


### PR DESCRIPTION
Adds a new config option to set the ScreenInsets property on ScreenGuis. This is to help with Iris on mobile, where screen space is more restrictive by default. This property is next to IgnoreGuiInset, which must be set correctly, since they affect each other, and IgnoreGuiInset is set after ScreenInsets.

| IgnoreGuiInset | ScreenInsets        |
| ---------------- | ------------------- |
| true                  | None                   |
| true                  | DeviceSafeInsets |
| false                 | CoreUISafeInsets |
| true                  | TopbarSafeInsets |

This still follows the default behaviour, by which not setting a value to ScreenInsets, and setting IgnoreGuiInset to true will produce the same behaviour as before.