### PR TITLE
Fix Widget Type Validation Bug in Internal.lua

### DIFF
--- a/lib/Internal.lua
+++ b/lib/Internal.lua
@@ -470,13 +470,13 @@ return function(Iris: Types.Iris): Types.Internal
         table.freeze(arguments)
 
         local lastWidget = Internal._lastVDOM[ID]
-		if lastWidget then
-			if Internal._refreshCounter > 0 or widgetType ~= lastWidget.type then
-				-- every widget is being redrawn, or this widget type has changed
-				Internal._DiscardWidget(lastWidget)
-				lastWidget = nil
-			end
-		end
+        if lastWidget then
+            if Internal._refreshCounter > 0 or widgetType ~= lastWidget.type then
+                -- every widget is being redrawn, or this widget type has changed
+                Internal._DiscardWidget(lastWidget)
+                lastWidget = nil
+            end
+        end
         local thisWidget = if lastWidget == nil then Internal._GenNewWidget(widgetType, arguments, states, ID) else lastWidget
 
         local parentWidget = thisWidget.parentWidget

--- a/lib/Internal.lua
+++ b/lib/Internal.lua
@@ -470,14 +470,18 @@ return function(Iris: Types.Iris): Types.Internal
         table.freeze(arguments)
 
         local lastWidget = Internal._lastVDOM[ID]
-        if lastWidget and widgetType == lastWidget.type then
-            -- found a matching widget from last frame.
-            if Internal._refreshCounter > 0 then
-                -- we are redrawing every widget.
-                Internal._DiscardWidget(lastWidget)
-                lastWidget = nil
-            end
-        end
+		if lastWidget then
+			if widgetType ~= lastWidget.type then
+				lastWidget = nil
+			else
+				-- found a matching widget from last frame.
+				if Internal._refreshCounter > 0 then
+					-- we are redrawing every widget.
+					Internal._DiscardWidget(lastWidget)
+					lastWidget = nil
+				end
+			end
+		end
         local thisWidget = if lastWidget == nil then Internal._GenNewWidget(widgetType, arguments, states, ID) else lastWidget
 
         local parentWidget = thisWidget.parentWidget

--- a/lib/Internal.lua
+++ b/lib/Internal.lua
@@ -471,15 +471,10 @@ return function(Iris: Types.Iris): Types.Internal
 
         local lastWidget = Internal._lastVDOM[ID]
 		if lastWidget then
-			if widgetType ~= lastWidget.type then
+			if Internal._refreshCounter > 0 or widgetType ~= lastWidget.type then
+				-- every widget is being redrawn, or this widget type has changed
+				Internal._DiscardWidget(lastWidget)
 				lastWidget = nil
-			else
-				-- found a matching widget from last frame.
-				if Internal._refreshCounter > 0 then
-					-- we are redrawing every widget.
-					Internal._DiscardWidget(lastWidget)
-					lastWidget = nil
-				end
 			end
 		end
         local thisWidget = if lastWidget == nil then Internal._GenNewWidget(widgetType, arguments, states, ID) else lastWidget


### PR DESCRIPTION
The logic in _Insert meant that there is no branch when the widgetType and lastWidget.type did not match. I don't think there's any intentional reason for this, and it was just an oversight.

Code to demonstrate the bug:
```lua
Iris:Connect(function()
	a = Iris.Checkbox().isChecked:get() and Iris.Button("Hello") or Iris.Text("Hello")
end)
```
Without this fix, this code will never create a button in place of text, regardless of which widget is being called

I haven't fully validated that this fix doesn't cause any side effects