### PR TITLE
feat: add AI agent skill for Iris 2.5.1

### DIFF
--- a/skills/iris/GENERATION.md
+++ b/skills/iris/GENERATION.md
@@ -1,0 +1,4 @@
+# Generation Info
+
+- **Source:** upstream Iris (github.com/SirMallard/Iris) — `docs/` folder (getting_started, widgets, states, events, config, lifecycle, common_issues), README, and source snapshot `lib/API.lua`, `lib/init.lua`, `lib/config.lua`, `lib/Internal.lua` (Iris 2.5.1)
+- **Generated:** 2026-08-01

--- a/skills/iris/SKILL.md
+++ b/skills/iris/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: iris
+description: Guide for building debug, visualization, and content-creation UI in Roblox with the Iris immediate-mode GUI module. Use when writing Iris widget code, wiring widget state to game values, theming via config, choosing between state types, or fixing common Iris errors like End() mismatches, init-once failures, or yields inside the UI thread.
+---
+
+# Iris (Roblox Immediate-Mode GUI)
+
+Iris is an immediate-mode GUI library for Roblox, based on Dear ImGui. You declare UI every frame instead of keeping references to instances. There are no click events and no stored handles to widgets: each frame you call the widget, check its return values, and let Iris create/destroy/parent all UI instances automatically.
+
+This differs from Roblox's retained mode (instances + `MouseButton1Click` connections). With Iris, writing `Iris.Button({"Save"})` every frame makes a button exist for that frame; dropping the call removes it.
+
+## Setup
+
+- Install as a Wally package (`sirmallard/iris`), as an rbxm from the latest GitHub release, or build from source. No external dependencies.
+- Place Iris somewhere on the client (`StarterPlayerScripts` or `ReplicatedStorage`) and require it from client scripts only. Works under PlayerGui, CoreGui, BillboardGui, SurfaceGui, and PluginGui.
+- Types are available via `require(path.to.Iris.PubTypes)`, which exports typed `Widget`, `State<T>`, and per-widget types.
+
+```lua
+local StarterPlayerScripts = game.StarterPlayer.StarterPlayerScripts
+local Iris = require(StarterPlayerScripts.Client.Iris).Init()
+```
+
+- **`Iris.Init(parentInstance?, eventConnection?, allowMultipleInits?)` may be called exactly once per client.** It starts the cycle and returns Iris. Options: `parentInstance` is a `BasePlayerGui | GuiBase2d` to place UI under (defaults to PlayerGui); `eventConnection` is the cycle signal, a `() -> number` function, or `false` to drive `Internal._cycle` yourself (defaults to `RunService.Heartbeat`); `allowMultipleInits = true` makes later `Init()` calls silently no-op instead of erroring. Initialise from a single early entry point (e.g. `ReplicatedFirst`) so other scripts can `require` Iris without calling `.Init()` again.
+- `Iris:Connect(fn)` runs `fn` every cycle, before Iris' internal cycle. It returns a function you can call to disconnect. You are not limited to `Connect` — Iris code can live in any callback that runs consistently every frame before the cycle, e.g. a weapon system's own `update(dt)`.
+- Lifecycle controls: `Iris.Shutdown()` stops Iris permanently (cannot be restarted); `Iris.Disabled = true` freezes rendering without destroying widgets; `Iris.ForceRefresh()` destroys and regenerates every instance (expensive — never per-frame).
+- `Iris.Append(guiInstance)` inserts an arbitrary Roblox GuiObject into the current parent widget.
+- Quick smoke test: `Iris.Init()` then `Iris:Connect(Iris.ShowDemoWindow)`. The demo window (`Iris.ShowDemoWindow`) shows every widget and is the best reference for the full API; the source is `lib/demoWindow.lua`.
+
+## Core API Model
+
+Every widget is a function taking two arguments: a **positional arguments array** (required, can be `{}`) and an **optional state dictionary** keyed by state name.
+
+```lua
+Iris.WidgetName({ arg1, arg2 }, { stateName = state })
+```
+
+- Arguments are passed by position: `Iris.Window({"Title", nil, nil, nil, true})`. Order matters; use `Iris.Args.Widget.Argument` as named indices for rarely used args, e.g. `Iris.Window({[Iris.Args.Window.Title] = "Title", [Iris.Args.Window.NoClose] = true})`.
+- **String-keyed argument tables error** (`{Title = "x"}` is invalid). Only the states dictionary uses string keys.
+- A widget with children (Window, Tree, CollapsingHeader, Table, Combo, SameLine, MenuBar, Indent, ...) must be closed with a matching `Iris.End()`. Use `do ... end` blocks to pair them visibly.
+- Events are methods on the returned widget that return booleans. They fire on the frame after the action so any visual change propagates first.
+- Widgets are identified per frame by the source line they were called from; calling the same widget on inconsistent lines across frames creates duplicates. To keep a widget persistent when its call site varies between frames (or across separate code paths), override the generated ID: `Iris.PushId(id)` / `Iris.PopId()` for all subsequent widgets, or `Iris.SetNextWidgetID(id)` for a single next widget (also the pattern for reusing a window with `Iris.Append`).
+
+## Widget + Event Pattern
+
+```lua
+Iris.Window({"My Second Window"}, { size = Iris.State(Vector2.new(300, 400)) })
+    Iris.Text({"The current time is: " .. time()})
+    Iris.InputText({"Enter Text"})
+
+    if Iris.Button({"Click me"}).clicked() then
+        print("button was clicked")
+    end
+
+    Iris.InputColor4()
+
+    Iris.Tree()
+        for i = 1, 8 do
+            Iris.Text({"Text in a loop: " .. i})
+        end
+    Iris.End()
+Iris.End()
+```
+
+Common events: `clicked()`, `hovered()` (continuous), `checked()`, and window events `opened()`, `closed()`, `collapsed()`, `uncollapsed()`. Buttons also expose `rightClicked()`, `doubleClicked()`, and `ctrlClicked()`. Window also accepts `NoTitleBar`, `NoBackground`, `NoCollapse`, `NoClose`, `NoMove`, `NoScrollbar`, `NoResize`, `NoNav`, `NoMenu` booleans.
+
+## Widgets
+
+The full catalog — every widget with its exact Arguments / Events / States — is in `references/widgets.md`. Common widgets:
+
+| Widget | Purpose | Key args | Key events / states |
+|---|---|---|---|
+| `Iris.Window` | Top-level container (every widget descends from one) | `Title`, `No*` flags | `opened()`, `closed()`; states `size`, `position`, `isOpened`, `isUncollapsed` |
+| `Iris.Text` | Label | `Text`, `Wrapped?`, `Color?`, `RichText?` | `hovered()` |
+| `Iris.Button` | Clickable | `Text`, `Size?` | `clicked()`, `rightClicked()`, `doubleClicked()` |
+| `Iris.Checkbox` | Boolean toggle | `Text` | `checked()`, `unchecked()`; state `isChecked` |
+| `Iris.InputText` | Free text entry | `Text`, `TextHint?`, `ReadOnly?`, `MultiLine?` | `textChanged()`; state `text` |
+| `Iris.InputNum` | Typed number | `Text`, `Increment?`, `Min?`, `Max?`, `Format?`, `NoButtons?` | `numberChanged()`; state `number` |
+| `Iris.DragNum` | Drag-to-edit number | `Text`, `Increment?`, `Min?`, `Max?` | `numberChanged()`; state `number` |
+| `Iris.SliderNum` | Slider (defaults 0..100) | `Text`, `Increment? = 1`, `Min? = 0`, `Max? = 100` | `numberChanged()`; state `number` |
+| `Iris.InputColor3` / `InputColor4` | Color input | `Text`, `UseFloats?`, `UseHSV?` | state `color` (+ `transparency` for Color4) |
+| `Iris.Combo` / `Iris.Selectable` | Dropdown from selectables | `Text`, `NoButton?`, `NoPreview?` | `changed()`; shared state `index` |
+| `Iris.ComboArray` / `Iris.ComboEnum` | Dropdown from array / enum | `(args, states?, array\|enum)` — 3rd param is the choices | state `index` |
+| `Iris.Tree` / `Iris.CollapsingHeader` | Collapsible container | `Text`, `DefaultOpen?` | `collapsed()`, `uncollapsed()`; state `isUncollapsed` |
+| `Iris.SameLine` / `Iris.Indent` | Layout | `Width?` | — |
+| `Iris.Tooltip` | Hover help | `Text` | gate on another widget's `hovered()` |
+| `Iris.Separator` / `Iris.SeparatorText` | Dividers | `Text` (SeparatorText) | — |
+| `Iris.MenuBar` + `Iris.Menu` + `Iris.MenuItem`/`MenuToggle` | Menu system | `Text`, `KeyCode?`, `ModifierKey?` (display-only) | `clicked()`, `checked()` |
+| `Iris.ProgressBar` | Progress | `Text`, `Format?` | state `progress` |
+| `Iris.PlotLines` / `Iris.PlotHistogram` | Graphs | `Text`, `Height?`, `Min?`, `Max?`, `TextOverlay?` | state `values` |
+| `Iris.Table` | Grid layout | `NumColumns`, `Header?`, `RowBackground?`, ... | column helpers `NextColumn()` etc. |
+| `Iris.TabBar` + `Iris.Tab` | Tabs | `Text`, `Hideable?` | shared state `index` |
+| `Iris.Image` / `Iris.ImageButton` | Image display / button | `Image`, `Size`, `ScaleType?` | button click events |
+
+Special call forms to remember:
+- `Iris.ComboArray(arguments, states?, array)` and `Iris.ComboEnum(arguments, states?, enumType)` generate their own Selectable children — do **not** call `Iris.End()` after them.
+- `Iris.Table` uses helper calls, not children ordering: `Iris.NextColumn()`, `Iris.NextRow()`, `Iris.SetColumnIndex(i)`, `Iris.SetRowIndex(i)`, `Iris.NextHeaderColumn()`, `Iris.SetHeaderColumnIndex(i)`, `Iris.SetColumnWidth(i, width)`.
+
+## State
+
+A State is a table holding a value plus connected widgets/callbacks; setting it updates dependent widget UI. States replace C++-style pointers in Luau (tables pass by reference).
+
+- `Iris.State(initial)` — base state.
+- `Iris.VariableState(value, setter)` — links a state to a local variable; the setter writes the widget's value back to your variable.
+  ```lua
+  local myNumber = 5
+  local state = Iris.VariableState(myNumber, function(value) myNumber = value end)
+  Iris.DragNum({"My number"}, { number = state })
+  ```
+- `Iris.TableState(table, key[, callback])` — links to a table field; syncs both ways without a setter. The optional third arg is an interception callback run on state change that gates the table write: `tab[key]` is updated only when it returns truthy (return `false` to handle the write yourself, e.g. to run side effects).
+  ```lua
+  local data = { myNumber = 5 }
+  Iris.DragNum({"My number"}, { number = Iris.TableState(data, "myNumber") })
+  ```
+- `Iris.WeakState(value)` — like State, but calling it by ID clears all connected widgets/callbacks while keeping the value (useful for disconnecting widgets).
+- `Iris.ComputedState(state, fn)` — derives a state that stays in sync with another state.
+
+Pass states to widgets as `{ name = state }` or read them back from a created widget: `local win = Iris.Window({"W"}); win.state.position`. Use states when a widget value is needed outside the widget call or to give widgets an initial value.
+
+### State methods
+
+A state object has `:get()`, `:set(value, force?)`, `:onChange(callback)`, and `:changed()`. `:get()` is preferred over reading `.value`.
+
+- **Use `:set()` to mutate a state, not `.value = x`.** Assigning `.value` directly does not propagate to connected widgets or fire `onChange` callbacks; `:set()` does.
+- Register `:onChange()` callbacks **once per state's lifetime**, never inside the per-frame widget block — calling it every frame leaks one callback per frame.
+- **Never call `:set()` on a state from inside that same state's `:onChange()` callback** — it causes an infinite callback loop.
+- `:changed()` returns whether the state changed this cycle (like an event).
+
+## Config / Theming
+
+- `Iris.UpdateGlobalConfig({...})` changes the global style (colors, text, sizing). Call sparingly, typically once before `Iris.Init()` — it redraws every widget (destroy + recreate).
+- Preset themes: `Iris.TemplateConfig.colorLight` / `colorDark` and `sizeClear` / `sizeDefault`, applied via `Iris.UpdateGlobalConfig(Iris.TemplateConfig.colorLight)`.
+- `Iris.PushConfig({...})` / `Iris.PopConfig()` scope config to a block and stack, so child widgets can differ from parents.
+- Every color option has a `Color` and a `Transparency` key (0 = opaque, 1 = transparent). Interaction variants are suffixed `Hovered` / `Active` (e.g. `ButtonColor`, `ButtonHoveredColor`, `ButtonActiveColor`). The exact key names (including `TableHeaderColor`, which is easy to miss) live in the upstream `config.lua`.
+- Sizing uses numbers/Vector2/UDim: `ItemWidth`, `ContentWidth` (proportion of a widget taken by its value box vs. label), `FramePadding`, `ItemSpacing`, `ItemInnerSpacing`, `WindowPadding`, etc.
+- Other global options: `UseScreenGUIs` (ScreenGUIs vs Frames), `ScreenInsets` / `IgnoreGuiInset` (should agree), `RichText`, `TextWrapped`, `DisplayOrderOffset`. Changing a widget's config between frames forces a redraw of that widget.
+
+## Constraints
+
+- **Never yield inside Iris code.** Iris must finish every frame or you get `Iris cycleCoroutine took too long to yield. Connected functions should not yield.` Use `task.spawn(...)` for async work and show the result once available.
+- Iris code must run every frame before the cycle for widgets to persist; a widget not called in a frame is discarded.
+- Use `Iris.TableState` / `VariableState` to bridge widget values into your game's data without breaking the no-yield rule.
+
+## Common Pitfalls
+
+- **`Iris.Init() can only be called once.`** — one `Init()` per client; require without `.Init()` everywhere else.
+- **`Iris:Connect() was called before calling Iris.Init(); always initialise Iris first.`** — just a warning; init first for deterministic ordering.
+- **`Too few calls to Iris.End().` / `Too many calls to Iris.End().`** — every parent widget needs one matching `End()`. Errors or yields inside a widget block also cause this because the `End()` never runs.
+- **`Iris.Window({ Title = "x" })` errors** — arguments are positional; only states use string keys.
+- **Wrong `End()` count from conditional layouts** — keep `End()` calls unconditional and inside the same frame path as the parent widget.
+
+## Source Files
+
+This skill is derived from the upstream Iris documentation: the `docs/` folder of https://github.com/SirMallard/Iris (getting started, widgets, states, events, config, lifecycle, common issues), the repository README, and the Iris source snapshot (`lib/API.lua` for the widget catalog, `lib/init.lua` for the Iris API surface, `lib/config.lua` for config keys, `lib/Internal.lua` for the State class).

--- a/skills/iris/references/widgets.md
+++ b/skills/iris/references/widgets.md
@@ -1,0 +1,236 @@
+# Widget Reference
+
+Complete catalog of Iris widgets and their APIs, distilled from https://github.com/SirMallard/Iris/tree/main/lib/API.lua (Iris 2.5.1). Each entry lists the moonwave-documented arguments, events and states. `hasChildren` widgets must be paired with `Iris.End()`.
+
+Notation: `Arg? = default` means optional argument. `[CONFIG]` means the value falls back to the global config.
+
+## Window
+
+- `hasChildren: true`, `hasState: true`
+- Arguments: `Title: string`, `NoTitleBar? = false`, `NoBackground? = false`, `NoCollapse? = false`, `NoClose? = false`, `NoMove? = false`, `NoScrollbar? = false`, `NoResize? = false`, `NoNav? = false`, `NoMenu? = false`
+- Events: `opened()`, `closed()`, `collapsed()`, `uncollapsed()`, `hovered()`
+- States: `size: State<Vector2>? = Vector2.new(400, 300)`, `position: State<Vector2>?`, `isUncollapsed: State<boolean>? = true`, `isOpened: State<boolean>? = true`, `scrollDistance: State<number>?`
+
+The top-level container; every other widget must be a descendant of a window. Cannot contain embedded windows. `Iris.SetFocusedWindow(window)` brings a window to front.
+
+## Tooltip
+
+- `hasChildren: false`, `hasState: false`
+- Arguments: `Text: string`
+- Events: `hovered()`
+
+Displays a text label next to the cursor, typically gated on another widget's `hovered()`:
+```lua
+local text = Iris.Text({ "?" })
+if text.hovered() then
+    Iris.Tooltip({ "Helpful explanation" })
+end
+```
+
+## Menus
+
+### MenuBar
+- `hasChildren: true`, `hasState: false`
+- No arguments. Declares a menubar for the current window; must be called directly under a Window. Add `Iris.Menu(...)` children.
+
+### Menu
+- `hasChildren: true`, `hasState: true`
+- Arguments: `Text: string`
+- Events: `clicked()`, `opened()`, `closed()`, `hovered()`
+- States: `isOpened: State<boolean>?`
+
+A collapsible menu. Under a MenuBar it sits horizontally below the title; nested under another Menu it becomes a submenu with an arrow.
+
+### MenuItem
+- `hasChildren: false`, `hasState: false`
+- Arguments: `Text: string`, `KeyCode: Enum.KeyCode? = nil`, `ModifierKey: Enum.ModifierKey? = nil`
+- Events: `clicked()`, `hovered()`
+
+A button inside a menu. **KeyCode/ModifierKey only display the key name; they do not bind a connection.**
+
+### MenuToggle
+- `hasChildren: false`, `hasState: true`
+- Arguments: `Text: string`, `KeyCode? = nil`, `ModifierKey? = nil`
+- Events: `checked()`, `unchecked()`, `hovered()`
+- States: `isChecked: State<boolean>?`
+
+A togglable menu item; functionally a checkbox.
+
+## Format / Layout
+
+### Separator
+- `hasChildren: false`, `hasState: false`
+- No arguments. A horizontal line between widgets.
+
+### SeparatorText
+- `hasChildren: false`, `hasState: false`
+- Arguments: `Text: string`
+- A separator with a text label; good section header when a Tree is too heavy.
+
+### Indent
+- `hasChildren: true`, `hasState: false`
+- Arguments: `Width: number? = Iris._config.IndentSpacing`
+- Indents its children.
+
+### SameLine
+- `hasChildren: true`, `hasState: false`
+- Arguments: `Width: number? = Iris._config.ItemSpacing.X`, `VerticalAlignment? = Enum.VerticalAlignment.Center`, `HorizontalAlignment? = Enum.HorizontalAlignment.Center`
+- Positions children in a horizontal row.
+
+### Group
+- `hasChildren: true`, `hasState: false`
+- No arguments. Groups children into a single layout unit.
+
+## Text
+
+### Text
+- `hasChildren: false`, `hasState: false`
+- Arguments: `Text: string`, `Wrapped: boolean? = [CONFIG] false`, `Color: Color3? = Iris._config.TextColor`, `RichText: boolean? = [CONFIG] false`
+- Events: `hovered()`
+
+Deprecated aliases `Iris.TextWrapped` and `Iris.TextColored` exist; prefer `Text` with `Wrapped`/`Color` arguments.
+
+### InputText
+- `hasChildren: false`, `hasState: true`
+- Arguments: `Text: string? = "InputText"`, `TextHint: string? = ""`, `ReadOnly: boolean? = false`, `MultiLine: boolean? = false`
+- Events: `textChanged()` (fires when the box loses focus after a change), `hovered()`
+- States: `text: State<string>?`
+
+## Basic
+
+### Button
+- `hasChildren: false`, `hasState: false`
+- Arguments: `Text: string`, `Size: UDim2? = UDim2.fromOffset(0, 0)`
+- Events: `clicked()`, `rightClicked()`, `doubleClicked()`, `ctrlClicked()` (control key held), `hovered()`
+
+### SmallButton
+- Same as Button but no padding: Arguments `Text: string`, `Size: UDim2?`; same events.
+
+### Checkbox
+- `hasChildren: false`, `hasState: true`
+- Arguments: `Text: string`
+- Events: `checked()`, `unchecked()`, `hovered()`
+- States: `isChecked: State<boolean>?`
+
+### RadioButton
+- `hasChildren: false`, `hasState: true`
+- Arguments: `Text: string`, `Index: any` (the value the shared state is set to when clicked)
+- Events: `selected()`, `unselected()`, `active()` (if its Index equals the state), `hovered()`
+- States: `index: State<any>?`
+
+Use multiple RadioButtons sharing the same `index` state to represent one-of-many values.
+
+## Image
+
+### Image
+- `hasChildren: false`, `hasState: false`
+- Arguments: `Image: string` (texture asset id), `Size: UDim2`, `Rect: Rect?`, `ScaleType? = Enum.ScaleType.Stretch`, `ResampleMode? = Enum.ResampleMode.Default`, `TileSize? = UDim2.fromScale(1, 1)`, `SliceCenter: Rect?`, `SliceScale: number? = 1`
+- Events: `hovered()`
+- `TileSize` only used when `ScaleType = Tile`; `SliceCenter`/`SliceScale` only when `Slice`.
+
+### ImageButton
+- Same as Image plus button events: `clicked()`, `rightClicked()`, `doubleClicked()`, `ctrlClicked()`, `hovered()`.
+
+## Trees
+
+### Tree
+- `hasChildren: true`, `hasState: true`
+- Arguments: `Text: string`, `SpanAvailWidth: boolean? = false`, `NoIndent: boolean? = false`, `DefaultOpen: boolean? = false`
+- Events: `collapsed()`, `uncollapsed()`, `hovered()`
+- States: `isUncollapsed: State<boolean>?`
+
+### CollapsingHeader
+- `hasChildren: true`, `hasState: true`
+- Arguments: `Text: string`, `DefaultOpen: boolean? = false`
+- Events: `collapsed()`, `uncollapsed()`, `hovered()`
+- States: `isUncollapsed: State<boolean>?`
+
+Same as Tree but a larger title; mainly for first-level organization in a window.
+
+## Tabs
+
+### TabBar
+- `hasChildren: true`, `hasState: true`
+- States: `index: State<number>?`
+- Container for `Tab` children; the index (1-based) controls which tab is active.
+
+### Tab
+- `hasChildren: true`, `hasState: true`
+- Arguments: `Text: string`, `Hideable: boolean? = nil`
+- Events: `clicked()`, `hovered()`, `selected()`, `unselected()`, `active()`, `opened()`, `closed()`
+- States: `isOpened: State<boolean>?`
+- Must be directly under a TabBar (the TabBar owns the index; you cannot pass an index state to a Tab).
+
+## Input
+
+Shared argument pattern for all `Input*`/`Drag*`/`Slider*` numeric widgets:
+1. `Text: string? = "Input{type}"`
+2. `Increment: DataType? = nil`
+3. `Min: DataType? = nil`
+4. `Max: DataType? = nil`
+5. `Format: string | { string }? = [DYNAMIC]`
+
+Without an explicit `Format`, Iris infers a reasonable format from Increment/Min/Max (e.g. integers for 1/0/100) and prefixes boxes (`X:`, `Y:`, `Z:` for Vector3). Events: `numberChanged()`, `hovered()`. States: `number: State<DataType>?`, `editingText: State<boolean>?`.
+
+- `InputNum` — number. Extra arg `NoButtons: boolean? = false` (hide +/- buttons).
+- `InputVector2`, `InputVector3`, `InputUDim`, `InputUDim2`, `InputRect` — respective datatypes.
+- `DragNum`, `DragVector2`, `DragVector3`, `DragUDim`, `DragUDim2`, `DragRect` — drag-to-edit fields. Ctrl+click types a value; hold Shift for faster, Alt for slower dragging.
+- `SliderNum` (defaults `Increment=1, Min=0, Max=100`), `SliderVector2` (`{1,1}`, `{0,0}`, `{100,100}`), `SliderVector3`, `SliderUDim`, `SliderUDim2`, `SliderRect` — a grip constrained between Min and Max.
+- `InputColor3` — args `Text`, `UseFloats? = false` (0..1 floats vs 0..255 ints), `UseHSV? = false`, `Format`. States: `color: State<Color3>?`, `editingText: State<boolean>?`.
+- `InputColor4` — Color3 + alpha. States: `color: State<Color3>?`, `transparency: State<number>?`, `editingText: State<boolean>?`.
+- `InputEnum` — alias for `ComboEnum` (see Combo).
+
+## Combo
+
+### Selectable
+- `hasChildren: false`, `hasState: true`
+- Arguments: `Text: string`, `Index: any` (value stored in the shared state), `NoClick: boolean? = false`
+- Events: `selected()`, `unselected()`, `active()`, `clicked()`, `rightClicked()`, `doubleClicked()`, `ctrlClicked()`, `hovered()`
+- States: `index: State<any>` — a state shared between all selectables in the group.
+
+### Combo
+- `hasChildren: true`, `hasState: true`
+- Arguments: `Text: string`, `NoButton: boolean? = false` (hide dropdown button), `NoPreview: boolean? = false` (hide preview field)
+- Events: `opened()`, `closed()`, `changed()`, `clicked()`, `hovered()`
+- States: `index: State<any>`, `isOpened: State<boolean>?`
+- Children are `Selectable` items sharing the combo's `index` state.
+
+### ComboArray
+- Function form: `Iris.ComboArray(arguments, states?, selectionArray: { any })` — third parameter is the array of choices. Generates the combo and its Selectable children internally (it inserts them itself; don't call `Iris.End()` after it).
+
+### ComboEnum
+- Function form: `Iris.ComboEnum(arguments, states?, enumType: Enum)` — third parameter is an Enum. Generates a combo of the enum's items, storing the selected `EnumItem`.
+
+## Plots
+
+### ProgressBar
+- `hasChildren: false`, `hasState: true`
+- Arguments: `Text: string? = "Progress Bar"`, `Format: string? = nil` (custom label like `"29/54"`)
+- Events: `hovered()`, `changed()`
+- States: `progress: State<number>?`
+
+### PlotLines
+- `hasChildren: false`, `hasState: true`
+- Arguments: `Text? = "Plot Lines"`, `Height: number? = 0`, `Min: number? = min`, `Max: number? = max`, `TextOverlay: string? = ""`
+- Events: `hovered()`
+- States: `values: State<{number}>?`, `hovered: State<{number}>?` (read-only)
+
+### PlotHistogram
+- Same as PlotLines plus `BaseLine: number? = 0` argument (where bars start from). States: `values`, `hovered` (read-only).
+
+## Table
+
+- `hasChildren: true`, `hasState: false`
+- Arguments: `NumColumns: number` (cannot be changed later), `Header: boolean? = false`, `RowBackground: boolean? = false`, `OuterBorders: boolean? = false`, `InnerBorders: boolean? = false`, `Resizable: boolean? = false`, `FixedWidth: boolean? = false`, `ProportionalWidth: boolean? = false`, `LimitTableWidth: boolean? = false`
+- Events: `hovered()`
+- States: `widths: State<{ number }>?` — column widths when `Resizable` (0..1 proportions, or pixels >2 when `FixedWidth`)
+
+Column helpers (must be called directly within the table):
+- `Iris.NextColumn()` — next cell, wrapping to the next row at the last column.
+- `Iris.NextRow()` — first column of the next row.
+- `Iris.SetColumnIndex(index)` — move to a column in the same row (1..NumColumns).
+- `Iris.SetRowIndex(index)` — move to a row in the same column.
+- `Iris.NextHeaderColumn()` / `Iris.SetHeaderColumnIndex(index)` — move within the header row (row 0).
+- `Iris.SetColumnWidth(index, width)` — set a column's width via the `widths` state.
+
+To change `NumColumns` later, wrap in `Iris.PushConfig({ columns = numColumns })` / `Iris.PopConfig()` so Iris redraws the table. When growing the column count, keep the `widths` state array at least as long as the new column count.


### PR DESCRIPTION
## Add AI agent skill for Iris 2.5.1

Adds an AI agent skill for Iris 2.5.1 with the stuff an agent needs to actually work with Iris without constantly getting tripped up by its API.

### What's included

* `skills/iris/SKILL.md` — general Iris usage, setup, widgets, events, state, config/theming, and common gotchas.
* `skills/iris/references/widgets.md` — the full widget list with their arguments, events, and states.
* `skills/iris/GENERATION.md` — generation metadata and sources.

### Where it came from

The skill was built from the Iris 2.5.1 source and docs, including:

* `/lib` — the API, widget definitions, states, config, etc.
* `/docs` — the official Moonwave docs and README.

### Why

Iris has a few patterns that are pretty easy for AI agents to get wrong. Things like:

* forgetting `Iris.End()` for parent widgets
* passing widget arguments in the wrong format
* updating state with `.value` instead of `:set()`
* registering `:onChange()` callbacks every frame
* applying config at the wrong time

These usually result in code that looks reasonable but doesn't actually work.

The skill gives agents the relevant Iris patterns and API details up front, so they can hopefully get things right without going through a bunch of trial and error.

### How to keep it updated

This is kinda the part that's up for debate.

The skill is tied to a specific Iris version (`2.5.1`) and was generated from the source and docs for that version. That makes it clear what version the skill is targeting, but it also means it can get stale as Iris changes.

How this should be handled going forward is up to the maintainer and the rest of the community. It could be updated alongside new Iris releases, regenerated from newer source/docs, or handled in some other way.

For now, the important part is that the version the skill was built for is clearly stated, so it's possible to tell what it's based on.

### Install

```bash
npx skills add SirMallard/Iris
```